### PR TITLE
specify deps in useEffect and use useCallback for pushEvent

### DIFF
--- a/useLiveState.ts
+++ b/useLiveState.ts
@@ -1,5 +1,5 @@
 import LiveState from 'phx-live-state';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 const useLiveState = (liveState: LiveState, intialState: any) => {
   const [state, setState] = useState(intialState);
@@ -10,11 +10,11 @@ const useLiveState = (liveState: LiveState, intialState: any) => {
     return () => {
       liveState.removeEventListener('livestate-change', handleStateChange);
     };
-  });
+  }, [liveState]);
 
-  const pushEvent = (event, payload) => {
+  const pushEvent = useCallback((event: string, payload: any) => {
     liveState.pushEvent(event, payload);
-  }
+  }, [liveState]);
 
   return [state, pushEvent];
 }


### PR DESCRIPTION
To avoid running calling the effect function on every rerender deps need to be specified. Makes sense to mark `liveState` as one.

To avoid creating new `pushEvent` function on each rerender (and potentially cause unneeded rerenders if it is used as a prop or as a dep) `useCallback` can be used.

Specify type of `event` argument as a string in `pushEvent`.

Also looking at published filed seems that `build` folder is missing but there are `useLiveState.ts` and `tsconfig.json`. I think it makes sense to add `files` field to `package.json` to prevent exposing unnecessary files.